### PR TITLE
fixed winner page error that showed both loser players

### DIFF
--- a/frontend/src/components/GamePage/index.tsx
+++ b/frontend/src/components/GamePage/index.tsx
@@ -50,8 +50,10 @@ function GamePage(props: GamePageProps) {
 	useEffect(() => {
 		if (!user || !user.id) return;
 		gameSocket.on(user.id.toString(), (newGameId) => {
-			setGameId(newGameId);
-			setIsConfigComplete(true);
+			if (typeof newGameId === "number") {
+				setGameId(String(newGameId));
+				setIsConfigComplete(true);
+			}
 		});
 	}, [user]);
 


### PR DESCRIPTION
Issue #180: Tela de vencedor agora mostra corretamente quando o playerId é igual ao gameId